### PR TITLE
feat: add dark mode styling to progression builder

### DIFF
--- a/src/components/chord-builder/ChordProgressionBuilder.tsx
+++ b/src/components/chord-builder/ChordProgressionBuilder.tsx
@@ -60,10 +60,10 @@ const ChordProgressionBuilder = () => {
       <div className="max-w-4xl mx-auto space-y-6">
         {/* Header with Readex Pro font */}
         <div className="text-center">
-          <h1 className="text-3xl font-readex font-bold text-gray-800 mb-2">
+          <h1 className="text-3xl font-readex font-bold text-gray-800 dark:text-gray-200 mb-2">
             Chord Progression Builder
           </h1>
-          <p className="text-gray-600 font-inclusive-sans">
+          <p className="text-gray-600 dark:text-gray-300 font-inclusive-sans">
             Pick a key, drag chords from the wheel, and build your progression
           </p>
         </div>
@@ -76,8 +76,8 @@ const ChordProgressionBuilder = () => {
         />
 
         {/* Selected Progression Drop Zone */}
-        <div className="bg-white rounded-xl shadow-lg p-6">
-          <h2 className="text-xl font-readex font-semibold text-gray-800 mb-4 text-center">
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6 border border-gray-200 dark:border-gray-700">
+          <h2 className="text-xl font-readex font-semibold text-gray-800 dark:text-gray-200 mb-4 text-center">
             Selected Progression
           </h2>
           <ProgressionDropZone
@@ -89,30 +89,30 @@ const ChordProgressionBuilder = () => {
         </div>
 
         {/* Controls */}
-        <div className="bg-white rounded-xl shadow-lg p-6">
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6 border border-gray-200 dark:border-gray-700">
           <div className="flex flex-wrap gap-4 justify-between">
             <button
               onClick={clearProgression}
-              className="px-6 py-3 bg-red-100 text-red-700 rounded-lg hover:bg-red-200 transition-colors font-medium"
+              className="px-6 py-3 bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300 rounded-lg hover:bg-red-200 dark:hover:bg-red-800 border border-red-200 dark:border-red-700 transition-colors font-medium"
             >
               Clear All
             </button>
             <button
               onClick={() => void handlePlay()}
               disabled={isPlaying || progression.length === 0}
-              className="px-6 py-3 bg-green-500 text-white rounded-lg hover:bg-green-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed font-medium"
+              className="px-6 py-3 bg-green-500 text-white dark:bg-green-600 rounded-lg hover:bg-green-600 dark:hover:bg-green-500 border border-green-700 dark:border-green-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed font-medium"
             >
               {isPlaying ? 'Playing...' : 'Play Progression'}
             </button>
           </div>
-          
+
           {progression.length > 0 && (
-            <div className="mt-4 p-4 bg-gray-50 rounded-lg">
-              <h3 className="font-medium text-gray-700 mb-2">Roman Numeral Analysis</h3>
-              <p className="text-sm text-gray-600">
+            <div className="mt-4 p-4 bg-gray-50 dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700">
+              <h3 className="font-medium text-gray-700 dark:text-gray-300 mb-2">Roman Numeral Analysis</h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
                 <strong>Key:</strong> {selectedKey} Major
               </p>
-              <p className="text-sm text-gray-600">
+              <p className="text-sm text-gray-600 dark:text-gray-400">
                 <strong>Progression:</strong> {progression.map(item => item.roman || '?').join(' - ')}
               </p>
             </div>


### PR DESCRIPTION
## Summary
- add dark theme colors for progression builder header and containers
- style buttons and analysis panel with dark-mode classes and borders

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-unsafe-assignment and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cba20f2883328978b104d6e4787f