### PR TITLE
feat: add transition-enabled dropdown component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { ScoreboardProvider } from './components/classroom/Scoreboard'
 import { ChordBuilderProvider } from './contexts/ChordBuilderContext';
 import { CollaborationProvider } from './contexts/CollaborationContext';
 import ErrorBoundary from './components/common/ErrorBoundary';
+import Dropdown from './components/common/Dropdown';
 import './styles/responsive-diagrams.css'
 import { StudentView } from './components/student/StudentView';
 
@@ -121,11 +122,9 @@ function App() {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 9l6 6 6-6" />
           </svg>
         </button>
-        {isMoreOpen && (
-          <div className="absolute right-0 mt-2 flex flex-col bg-white/95 dark:bg-gray-800/95 border border-gray-200/50 dark:border-gray-700/50 rounded-2xl shadow-2xl backdrop-blur-lg p-3 z-20 min-w-[200px]">
-            {moreNavLinks}
-          </div>
-        )}
+        <Dropdown isOpen={isMoreOpen} onClose={() => setIsMoreOpen(false)}>
+          {moreNavLinks}
+        </Dropdown>
       </div>
     </>
   )

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,0 +1,48 @@
+import { ReactNode, useEffect, useRef } from 'react'
+
+interface DropdownProps {
+  isOpen: boolean
+  onClose: () => void
+  children: ReactNode
+}
+
+export default function Dropdown({ isOpen, onClose, children }: DropdownProps) {
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown)
+      document.addEventListener('mousedown', handleClickOutside)
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isOpen, onClose])
+
+  return (
+    <>
+      {isOpen && <div className="fixed inset-0 z-10" onClick={onClose} aria-hidden="true" />}
+      <div
+        ref={menuRef}
+        className={`absolute right-0 mt-2 flex flex-col bg-white/95 dark:bg-gray-800/95 border border-gray-200/50 dark:border-gray-700/50 rounded-2xl shadow-2xl backdrop-blur-lg p-3 min-w-[200px] origin-top-right transform transition-[opacity,transform] duration-200 ${isOpen ? 'opacity-100 scale-100 z-20' : 'opacity-0 scale-95 pointer-events-none z-20'}`}
+      >
+        {children}
+      </div>
+    </>
+  )
+}
+


### PR DESCRIPTION
## Summary
- wrap "More" menu in reusable `Dropdown` component with smooth fade/scale transitions
- close dropdown on outside click or `Esc` with overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6cba2fa6483328e96d7787126b93c